### PR TITLE
adding custom url token

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ display_dh(t)
 streamlit run deephaven_app.py
 ```
 
+## Alternate Deephaven Server URL
+By default, the Deephaven server is located at `http://localhost:{port}`, where `{port}` is the port set in the Deephaven server creation call. If the server is not there, such as when running Streamlit in a Docker container, modify the `DEEPHAVEN_ST_URL` environmental variable to the correct URL before calling `display_dh`. 
+```python
+import os
+os.environ["DEEPHAVEN_ST_URL"] = "http://localhost:1234"
+```
+
 For more information on running Streamlit, see the [Streamlit documentation](https://docs.streamlit.io/).
 
 ## Development

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="streamlit-deephaven",
-    version="0.0.5",
+    version="0.0.6",
     author="Deephaven Data Labs",
     author_email="support@deephaven.io",
     description="Streamlit Deephaven Component",

--- a/streamlit_deephaven/__init__.py
+++ b/streamlit_deephaven/__init__.py
@@ -88,9 +88,16 @@ def display_dh(widget, height=600, width=None, object_id=None, key=None):
     if object_id is None:
         object_id = f"__w_{str(uuid4()).replace('-', '_')}"
 
-    # Generate the iframe_url from the object type
     server_url = f"http://localhost:{Server.instance.port}"
-    iframe_url = f"{server_url}/iframe/{_path_for_object(widget)}/?name={object_id}"
+
+    if "DEEPHAVEN_ST_URL" in os.environ:
+      server_url = os.environ["DEEPHAVEN_ST_URL"]
+
+    if not server_url.endswith("/"):
+      server_url = f"{server_url}/"
+
+    # Generate the iframe_url from the object type
+    iframe_url = f"{server_url}iframe/{_path_for_object(widget)}/?name={object_id}"
     object_type = _str_object_type(widget)
 
     # Add the table to the main modules globals list so it can be retrieved by the iframe


### PR DESCRIPTION
Fixes #2 

Ran in dev mode:
`DH_DEV_MODE=true streamlit run streamlit_deephaven/__init__.py`

this code:
```
import streamlit as st

start_server()

st.subheader("Deephaven Component Demo")

# Create a deephaven component with a simple table
# Create a table and display it
from deephaven import time_table
from deephaven.plot.figure import Figure
t = time_table("00:00:01").update(["x=i", "y=Math.sin(x)", "z=Math.cos(x)"])
os.environ["DEEPHAVEN_ST_URL"] = "http://localhost:1234"
display_dh(t, height=200)

f = Figure().plot_xy(series_name="Sine", t=t, x="x", y="y").show()
f = f.plot_xy(series_name="Cosine", t=t, x="x", y="z").show()
display_dh(f, height=400)
```
And verified that the iframe url started with "http://localhost:1234"